### PR TITLE
Add factory posts

### DIFF
--- a/increase_watches.sh
+++ b/increase_watches.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Increases the maximum number of file system watches
+# This solves problems with automatic recompiling
+sudo sysctl fs.inotify.max_user_watches=524288
+sudo sysctl -p

--- a/simulationfactory/.gitignore
+++ b/simulationfactory/.gitignore
@@ -56,3 +56,4 @@ sketch
 # End of https://www.toptal.com/developers/gitignore/api/react,visualstudiocode
 
 package-lock.json
+**/.eslintcache

--- a/simulationfactory/package.json
+++ b/simulationfactory/package.json
@@ -13,7 +13,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.14.0",
     "react-router-dom": "5.2.0",
-    "react-scripts": "^4.0.0"
+    "react-scripts": "^4.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/simulationfactory/src/pages/Factorypage.js
+++ b/simulationfactory/src/pages/Factorypage.js
@@ -1,15 +1,17 @@
-import React, { useState } from "react";
+import React from "react";
 import Grid from "@material-ui/core/Grid";
 import Card from "@material-ui/core/Card";
 import CardActions from "@material-ui/core/CardActions";
 import Button from "@material-ui/core/Button";
-import { Menu, MenuItem } from '@material-ui/core';
 import Table from '../components/Table'
 
 import {
+  Menu, 
+  MenuItem,
   Tabs,
   Tab,
   TextField,
+  Tooltip,
   CardContent,
   Typography,
   Dialog,
@@ -23,6 +25,10 @@ import CreateStyles from "../util/Stylesheet";
 import Navigation from "../components/Navigation";
 import TabPanel from "../components/TabPanel";
 import { RegisterRoutes } from "../util/RouteBuilder";
+import {
+  InitializeSimulation,
+  InitializeFrame
+} from "../util/Backend";
 import Close from "@material-ui/icons/Close";
 
 function Factorypage(props) {
@@ -36,13 +42,7 @@ function Factorypage(props) {
   const [value, setValue] = React.useState(0);
   const [anchorEl, setAnchorEl] = React.useState(null);
 
-  const [tabList, setTabList] = React.useState([
-    {
-      key: 0,
-      id: 0,
-      type: 0,
-    },
-  ]);
+  const [tabList, setTabList] = React.useState([]);
 
   const [tabValue, setTabValue] = React.useState(0);
   const [open, setOpen] = React.useState(false);
@@ -52,7 +52,6 @@ function Factorypage(props) {
   // Information for backend
   const [simulationId, setSimulationId] = React.useState('');
   const [user, setUser] = React.useState({username: '', password: ''});
-  const [loggedIn, setLoggedIn] = React.useState(false);
   
   function handleChange(event, newValue) {
     setValue(newValue);
@@ -84,18 +83,21 @@ function Factorypage(props) {
     setOpenResourceAdd(false);
   };
   function addPrompt() {
-    let id = tabList[tabList.length - 1].id + 1;
-    setTabList([...tabList, { key: id, id: id, type: 0 }]);
+    InitializeFrame({user: user, id: simulationId}, (r) => {
+      setTabList([...tabList, { key: r.id, id: r.id, type: 0 }]);
+    })
   };
 
   function addResponse() {
-    let id = tabList[tabList.length - 1].id + 1;
-    setTabList([...tabList, { key: id, id: id, type: 1 }]);
+    InitializeFrame({user: user, id: simulationId}, (r) => {
+      setTabList([...tabList, { key: r.id, id: r.id, type: 1 }]);
+    })
   };
 
   function addEvent() {
-    let id = tabList[tabList.length - 1].id + 1;
-    setTabList([...tabList, { key: id, id: id, type: 2 }]);
+    InitializeFrame({user: user, id: simulationId}, (r) => {
+      setTabList([...tabList, { key: r.id, id: r.id, type: 2 }]);
+    })
   };
 
   function deleteTab(e) {
@@ -212,7 +214,7 @@ function Factorypage(props) {
   function renderSubmitButton() {
     return (
       <Button variant="contained" color="primary" size="medium" 
-        onClick={() => setLoggedIn(true)}>
+        onClick={() => InitializeSimulation(user, (r) => setSimulationId(r.id))}>
         Begin
       </Button>
     )
@@ -337,6 +339,11 @@ function Factorypage(props) {
                   Add response
                 </Button>
               </Grid>
+              <Grid item xs={12} sm={1}>
+                <Tooltip title="Participants need this id to run your simulation. Save it somewhere you won't lose it!">
+                  <div>Your simulation id is {simulationId}</div>
+                </Tooltip>
+              </Grid>
             </Grid>
             <Grid item xs={12} sm={6}>
               <div className={Styles.root}>
@@ -370,10 +377,10 @@ function Factorypage(props) {
     );
   };
 
-  if (loggedIn) {
-    return renderFactoryPage();
-  } else {
+  if (simulationId == '') {
     return renderLogin();
+  } else {
+    return renderFactoryPage();
   }
 }
 RegisterRoutes(

--- a/simulationfactory/src/pages/Factorypage.js
+++ b/simulationfactory/src/pages/Factorypage.js
@@ -12,8 +12,6 @@ import {
   TextField,
   CardContent,
   Typography,
-  AppBar,
-  Toolbar,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -29,10 +27,7 @@ import Close from "@material-ui/icons/Close";
 
 function Factorypage(props) {
 
-  const { window } = props;
-  const { useState } = React;
-
-  const [inputList, setInputList] = useState([]);
+  const [inputList, setInputList] = React.useState([]);
   const onAddResponseClick = event => {
     setInputList(inputList.concat(<TextField id="prompt" label="Prompt" variant="filled" key={inputList.length} />));
   };
@@ -41,7 +36,7 @@ function Factorypage(props) {
   const [value, setValue] = React.useState(0);
   const [anchorEl, setAnchorEl] = React.useState(null);
 
-  const [tabList, setTabList] = useState([
+  const [tabList, setTabList] = React.useState([
     {
       key: 0,
       id: 0,
@@ -49,63 +44,61 @@ function Factorypage(props) {
     },
   ]);
 
-  const players = {};
-  const resources = {
-    player1_money: 0,
-    player2_money: 0,
-    env_money: 0,
-  };
-
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = React.useState(0);
   const [open, setOpen] = React.useState(false);
   const [openPlayerAdd, setOpenPlayerAdd] = React.useState(false);
   const [openResourceAdd, setOpenResourceAdd] = React.useState(false);
 
-  const handleChange = (event, newValue) => {
+  // Information for backend
+  const [simulationId, setSimulationId] = React.useState('');
+  const [user, setUser] = React.useState({username: '', password: ''});
+  const [loggedIn, setLoggedIn] = React.useState(false);
+  
+  function handleChange(event, newValue) {
     setValue(newValue);
   };
-  const handleMenuClick = (event) => {
+  function handleMenuClick(event) {
     setAnchorEl(event.currentTarget);
   };
-  const handleMenuClose = () => {
+  function handleMenuClose() {
     setAnchorEl(null);
   };
-  const handleSheetOpen = (event) => {
+  function handleSheetOpen(event) {
     setOpen(true);
   };
-  const handleSheetClose = (event) => {
+  function handleSheetClose(event) {
     setOpen(false);
   };
-  const handlePlayerAddOpen = (event) => {
+  function handlePlayerAddOpen(event) {
     setOpenPlayerAdd(true);
     setAnchorEl(null);;
   };
-  const handlePlayerAddClose = (event) => {
+  function handlePlayerAddClose(event) {
     setOpenPlayerAdd(false);
   };
-  const handleResourceAddOpen = (event) => {
+  function handleResourceAddOpen(event) {
     setOpenResourceAdd(true);
     setAnchorEl(null);
   };
-  const handleResourceAddClose = (event) => {
+  function handleResourceAddClose(event) {
     setOpenResourceAdd(false);
   };
-  const addPrompt = () => {
+  function addPrompt() {
     let id = tabList[tabList.length - 1].id + 1;
     setTabList([...tabList, { key: id, id: id, type: 0 }]);
   };
 
-  const addResponse = () => {
+  function addResponse() {
     let id = tabList[tabList.length - 1].id + 1;
     setTabList([...tabList, { key: id, id: id, type: 1 }]);
   };
 
-  const addEvent = () => {
+  function addEvent() {
     let id = tabList[tabList.length - 1].id + 1;
     setTabList([...tabList, { key: id, id: id, type: 2 }]);
   };
 
-  const deleteTab = (e) => {
+  function deleteTab(e) {
     e.stopPropagation();
 
     if (tabList.length === 1) {
@@ -192,177 +185,196 @@ function Factorypage(props) {
           </Card>
         );
     }
-  }
+  };
 
-  const [columns, setColumns] = useState([
-    { title: "Name", field: "name" },
-    {
-      title: "Surname",
-      field: "surname",
-      initialEditValue: "initial edit value",
-    },
-    { title: "Birth Year", field: "birthYear", type: "numeric" },
-    {
-      title: "Birth Place",
-      field: "birthCity",
-      lookup: { 34: "İstanbul", 63: "Şanlıurfa" },
-    },
-  ]);
-
-  const [data, setData] = useState([
-    { name: "Mehmet", surname: "Baran", birthYear: 1987, birthCity: 63 },
-    { name: "Zerya Betül", surname: "Baran", birthYear: 2017, birthCity: 34 },
-  ]);
-
-  return (
-    <div className={Styles.root}>
-      <script src="xlsx.full.min.js"></script>
-      <Navigation TopbarMessage="Simulation Builder" Styles={Styles}>
-        <Button
-          className="SimMenuButton"
-          aria-controls="sim-menu"
-          aria-haspopup="true"
-          onClick={handleMenuClick}
-        >
-          Simulation Settings
-        </Button>
-        <Menu
-          id="simple-menu"
-          anchorEl={anchorEl}
-          keepMounted
-          open={Boolean(anchorEl)}
-          onClose={handleMenuClose}
-        >
-          <MenuItem onClick={handleSheetOpen}>Import Lookup Table</MenuItem>
-          <Dialog
-            onClose={handleSheetClose}
-            aria-labeledby="lookup-table-dialog"
-            open={open}
-          >
-            <DialogTitle id="lookup-table-title" onClose={handleSheetClose}>
-              Lookup Table Entry
-            </DialogTitle>
-            <DialogContent dividers>
-              <div style={{ width: "max-content" }}>
-                <Table x={25} y={25} />
-              </div>
-            </DialogContent>
-          </Dialog>
-          <MenuItem onClick={handlePlayerAddOpen}>Add Player</MenuItem>
-          <Dialog open={openPlayerAdd} onClose={handlePlayerAddClose} aria-labelledby="form-dialog-title">
-            <DialogTitle id="form-dialog-title">Add a Player</DialogTitle>
-              <DialogContent>
-                <DialogContentText>
-                  Enter the name of the player.
-                </DialogContentText>
-                <TextField
-                  autoFocus
-                  margin="dense"
-                  id="name"
-                  label="Name of Player to add"
-                  fullWidth
-                />
-              </DialogContent>
-            <DialogActions>
-              <Button onClick={handlePlayerAddClose} color="primary">
-                Cancel
-              </Button>
-              <Button onClick={handlePlayerAddClose} color="primary">
-                Add Player
-              </Button>
-            </DialogActions>
-          </Dialog>
-          <MenuItem onClick={handleResourceAddOpen}>Add Resource</MenuItem>
-          <Dialog open={openResourceAdd} onClose={handleResourceAddClose} aria-labelledby="form-dialog-title">
-            <DialogTitle id="form-dialog-title">Add a Resource</DialogTitle>
-              <DialogContent>
-                <DialogContentText>
-                  Enter the name of the resource.
-                </DialogContentText>
-                <TextField
-                  autoFocus
-                  margin="dense"
-                  id="name"
-                  label="Name of resource to add"
-                  fullWidth
-                />
-              </DialogContent>
-            <DialogActions>
-              <Button onClick={handleResourceAddClose} color="primary">
-                Cancel
-              </Button>
-              <Button onClick={handleResourceAddClose} color="primary">
-                Add Resource
-              </Button>
-            </DialogActions>
-          </Dialog>
-        </Menu>
-      </Navigation>
+  // Temporary code until login process is completed
+  function renderLogin() {
+    return (
       <main className={Styles.content}>
         <div className={Styles.toolbar} /> {/* Why is this necessary */}
-        <Grid container spacing={3} justify="center">
-          <Grid container spacing={1} justify="center">
-            <Grid item xs={12} sm={1}>
-              <Button
-                variant="contained"
-                color="primary"
-                size="medium"
-                onClick={addEvent}
-              >
-                Add event
-              </Button>
-            </Grid>
-            <Grid item xs={12} sm={1}>
-              <Button
-                variant="contained"
-                color="primary"
-                size="medium"
-                onClick={addPrompt}
-              >
-                Add prompt
-              </Button>
-            </Grid>
-            <Grid item xs={12} sm={1}>
-              <Button
-                variant="contained"
-                color="primary"
-                size="medium"
-                onClick={addResponse}
-              >
-                Add response
-              </Button>
-            </Grid>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <div className={Styles.root}>
-              <Tabs
-                orientation="vertical"
-                variant="scrollable"
-                value={value}
-                onChange={handleChange}
-                className={Styles.tabs}
-              >
-                {tabList.map((tab) => (
-                  <Tab
-                    key={tab.key.toString()}
-                    value={tab.id}
-                    label={"Node " + tab.id}
-                    icon={<Close id={tab.id} onClick={deleteTab} />}
-                    className="mytab"
-                  />
-                ))}
-              </Tabs>
-              {tabList.map((tab) => (
-                <TabPanel value={value} index={tab.key}>
-                  {renderCard(tab)}
-                </TabPanel>
-              ))}
-            </div>
-          </Grid>
-        </Grid>
+        <Card className={Styles.root}>
+          <CardContent>
+            <TextField id="username_field" label="Username" variant="filled"
+              onChange={(t) => setUser({username: t.target.value, password: user.password})}/>
+            <TextField id="password_field" label="Password" variant="filled"
+              onChange={(t) => setUser({password: t.target.value, username: user.username})}/>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            {renderSubmitButton()}
+          </CardContent>
+        </Card>
       </main>
-    </div>
-  );
+    )
+  };
+
+  function renderSubmitButton() {
+    return (
+      <Button variant="contained" color="primary" size="medium" 
+        onClick={() => setLoggedIn(true)}>
+        Begin
+      </Button>
+    )
+  };
+
+  function renderFactoryPage() {
+    return (
+      <div className={Styles.root}>
+        <script src="xlsx.full.min.js"></script>
+        <Navigation TopbarMessage="Simulation Builder" Styles={Styles}>
+          <Button
+            className="SimMenuButton"
+            aria-controls="sim-menu"
+            aria-haspopup="true"
+            onClick={handleMenuClick}
+          >
+            Simulation Settings
+          </Button>
+          <Menu
+            id="simple-menu"
+            anchorEl={anchorEl}
+            keepMounted
+            open={Boolean(anchorEl)}
+            onClose={handleMenuClose}
+          >
+            <MenuItem onClick={handleSheetOpen}>Import Lookup Table</MenuItem>
+            <Dialog
+              onClose={handleSheetClose}
+              aria-labeledby="lookup-table-dialog"
+              open={open}
+            >
+              <DialogTitle id="lookup-table-title" onClose={handleSheetClose}>
+                Lookup Table Entry
+              </DialogTitle>
+              <DialogContent dividers>
+                <div style={{ width: "max-content" }}>
+                  <Table x={25} y={25} />
+                </div>
+              </DialogContent>
+            </Dialog>
+            <MenuItem onClick={handlePlayerAddOpen}>Add Player</MenuItem>
+            <Dialog open={openPlayerAdd} onClose={handlePlayerAddClose} aria-labelledby="form-dialog-title">
+              <DialogTitle id="form-dialog-title">Add a Player</DialogTitle>
+                <DialogContent>
+                  <DialogContentText>
+                    Enter the name of the player.
+                  </DialogContentText>
+                  <TextField
+                    autoFocus
+                    margin="dense"
+                    id="name"
+                    label="Name of Player to add"
+                    fullWidth
+                  />
+                </DialogContent>
+              <DialogActions>
+                <Button onClick={handlePlayerAddClose} color="primary">
+                  Cancel
+                </Button>
+                <Button onClick={handlePlayerAddClose} color="primary">
+                  Add Player
+                </Button>
+              </DialogActions>
+            </Dialog>
+            <MenuItem onClick={handleResourceAddOpen}>Add Resource</MenuItem>
+            <Dialog open={openResourceAdd} onClose={handleResourceAddClose} aria-labelledby="form-dialog-title">
+              <DialogTitle id="form-dialog-title">Add a Resource</DialogTitle>
+                <DialogContent>
+                  <DialogContentText>
+                    Enter the name of the resource.
+                  </DialogContentText>
+                  <TextField
+                    autoFocus
+                    margin="dense"
+                    id="name"
+                    label="Name of resource to add"
+                    fullWidth
+                  />
+                </DialogContent>
+              <DialogActions>
+                <Button onClick={handleResourceAddClose} color="primary">
+                  Cancel
+                </Button>
+                <Button onClick={handleResourceAddClose} color="primary">
+                  Add Resource
+                </Button>
+              </DialogActions>
+            </Dialog>
+          </Menu>
+        </Navigation>
+        <main className={Styles.content}>
+          <div className={Styles.toolbar} /> {/* Why is this necessary */}
+          <Grid container spacing={3} justify="center">
+            <Grid container spacing={1} justify="center">
+              <Grid item xs={12} sm={1}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="medium"
+                  onClick={addEvent}
+                >
+                  Add event
+                </Button>
+              </Grid>
+              <Grid item xs={12} sm={1}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="medium"
+                  onClick={addPrompt}
+                >
+                  Add prompt
+                </Button>
+              </Grid>
+              <Grid item xs={12} sm={1}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="medium"
+                  onClick={addResponse}
+                >
+                  Add response
+                </Button>
+              </Grid>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <div className={Styles.root}>
+                <Tabs
+                  orientation="vertical"
+                  variant="scrollable"
+                  value={value}
+                  onChange={handleChange}
+                  className={Styles.tabs}
+                >
+                  {tabList.map((tab) => (
+                    <Tab
+                      key={tab.key.toString()}
+                      value={tab.id}
+                      label={"Node " + tab.id}
+                      icon={<Close id={tab.id} onClick={deleteTab} />}
+                      className="mytab"
+                    />
+                  ))}
+                </Tabs>
+                {tabList.map((tab) => (
+                  <TabPanel value={value} index={tab.key}>
+                    {renderCard(tab)}
+                  </TabPanel>
+                ))}
+              </div>
+            </Grid>
+          </Grid>
+        </main>
+      </div>
+    );
+  };
+
+  if (loggedIn) {
+    return renderFactoryPage();
+  } else {
+    return renderLogin();
+  }
 }
 RegisterRoutes(
   Factorypage,

--- a/simulationfactory/src/util/Backend.js
+++ b/simulationfactory/src/util/Backend.js
@@ -1,53 +1,91 @@
-import SimulationInstance from "../simulation-schema/js/SimulationInstance";
+import IdRequest from "../simulation-schema/js/IdRequest";
+import IdResponse from "../simulation-schema/js/IdResponse";
 import State from "../simulation-schema/js/State";
+import User from "../simulation-schema/js/User";
 import UserResponse from "../simulation-schema/js/UserResponse";
+
 
 let server_url = process.env.REACT_APP_SIMULATION_FACTORY_URL;
 
-export async function BeginSim(beginSim, callback) {
-    SimulationInstance.Validate(beginSim);
-    let fetch_url = `${server_url}/BeginSim.php`;
-    let fetch_body = {
-        method: "POST",
-        headers: new Headers(),
-        body: JSON.stringify(beginSim)
-    };
-    let response = await fetch(fetch_url, fetch_body);
-    if (response.ok) {
-        callback();
-    } else {
-        throw new Error(`Error ${response.status}: ${response.statusText}`)
-    }
+// Executes the BeginSim procedure on the backend
+// Args:
+//      request (object): The request to POST to the backend
+//      callback (object): The callback to execute once the backend responds.
+//                         This callback accepts no arguments.
+export async function BeginSim(request, callback) {
+    Post(request, callback, 'BeginSim', IdRequest);
 }
 
-export async function GetState(simulationInstance, callback) {
-    SimulationInstance.Validate(simulationInstance);
-    let fetch_url = `${server_url}/GetSimState.php`;
-    let fetch_body = {
-        method: "POST",
-        headers: new Headers(),
-        body: JSON.stringify(simulationInstance)
-    };
-    let response = await fetch(fetch_url, fetch_body);
-    if (response.ok) {
-        callback(State.FromJSON(await response.text()));
-    } else {
-        throw new Error(`Error ${response.status}: ${response.statusText}`)
-    }
+// Executes the GetSimState procedure on the backend
+// Args:
+//      request (object): The request to POST to the backend
+//      callback (object): The callback to execute once the backend responds.
+//                         This callback accepts one State argument.
+export async function GetState(request, callback) {
+    Post(request, callback, 'GetSimState', IdRequest, State);
 }
 
-export async function SubmitResponse(userResponse, callback) {
-    UserResponse.Validate(userResponse);
-    let fetch_url = `${server_url}/SubmitResponse.php`;
+// Executes the SubmitResponse procedure on the backend
+// Args:
+//      request (object): The request to POST to the backend
+//      callback (object): The callback to execute once the backend responds.
+//                         This callback accepts no arguments.
+export async function SubmitResponse(request, callback) {
+    Post(request, callback, 'SubmitResponse', UserResponse);
+}
+
+// Executes the CheckCredentials procedure on the backend
+// Args:
+//      request (object): The request to POST to the backend
+//      callback (object): The callback to execute once the backend responds.
+//                         This callback accepts no arguments.
+export async function CheckCredentials(request, callback) {
+    Post(request, callback, 'CheckCredentials', User);
+}
+
+// Executes the SimulationInitialization procedure on the backend
+// Args:
+//      request (object): The request to POST to the backend
+//      callback (object): The callback to execute once the backend responds.
+//                         This callback accepts one IdResponse argument.
+export async function InitializeSimulation(request, callback) {
+    Post(request, callback, 'SimulationInitialization', User, IdResponse);
+}
+
+// Executes the FrameInitialization procedure on the backend
+// Args:
+//      request (object): The request to POST to the backend
+//      callback (object): The callback to execute once the backend responds.
+//                         This callback accepts one IdResponse argument.
+export async function InitializeFrame(request, callback) {
+    Post(request, callback, 'FrameInitialization', IdRequest, IdResponse);
+}
+
+// Private method to issue a POST request to the backend
+// Args:
+//      request (object): The request object to post
+//      callback (function): The function to call once the backend responds. 
+//                           If responseValidator is null, the callback is called with no argument.
+//                           Otherwise, the callback is called with the backend's reponse as an argument
+//      backendProcedure (string): The procedure to request the backend to perform
+//      requestValidator (class): The validator class to use on the request object
+//      responseValidator (class): The validator class to use on the backend's response.
+//                                 If null, the callback is called with no argument. Defaults to null.
+async function Post(request, callback, backendProcedure, requestValidator, responseValidator=null) {
+    requestValidator.Validate(request);
+    let fetch_url = `${server_url}/${backendProcedure}.php`;
     let fetch_body = {
         method: "POST",
         headers: new Headers(),
-        body: JSON.stringify(userResponse)
+        body: JSON.stringify(request)
     };
     let response = await fetch(fetch_url, fetch_body);
     if (response.ok) {
-        //throw new Error(await response.text())
-        callback();
+        if (responseValidator == null) {
+            callback();
+        } else {
+            callback(responseValidator.FromJSON(await response.text()));
+        }
     } else {
         throw new Error(`Error ${response.status}: ${response.statusText}`)
     }


### PR DESCRIPTION
It's not pretty, but it works.
The Factorypage keeps track of simulation id, user credentials, and frame ids now.
- simulation id is stored in the `simulationId` variable
- user credentials are stored in the `user` variable
- frame ids are stored as the ids of the `tabList`

The factory page collects user credentials before doing anything else.
There's no support for `SimulationModification` just yet. Looks like you guys aren't really ready for that anyway.
No support for `FrameDeletion` either. I may do that in a separate PR.
I totally rewrote backend.js for you guys. It's much simpler to add new functions now, and it's heavily documented.
*Significant* changes were made to the simulation-schema, with respect to before. Not sure if you guys will have to update that manually.

It's all very quick and dirty, but quick and dirty is all we can afford right now.